### PR TITLE
Fix/filter rds

### DIFF
--- a/CpmAWS/classes/RdsCollection.py
+++ b/CpmAWS/classes/RdsCollection.py
@@ -1,4 +1,5 @@
 import logging
+from fnmatch import fnmatch
 
 from CpmAWS.core.Collection import Collection
 from CpmAWS.classes.RdsInstance import RdsInstance
@@ -26,3 +27,21 @@ class RdsCollection(Collection):
         for name in self.instances:
             logging.debug(name)
         return self.instances
+
+    def instanceBelongsToFilter(self, instance):
+        """As filters are not available for describe_db_instances, we need to
+        implement it here
+        @see https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-instances.html
+        """
+        for tag in self.parameters.tags:
+            key = tag["Name"][4:]
+            values = tag["Values"]
+            if key == "Name":
+                for name in values:
+                    if not fnmatch(instance.name, name):
+                        return False
+            else:
+                if instance.tags.get(key) not in values:
+                    return False
+
+        return super(RdsCollection, self).instanceBelongsToFilter(instance)

--- a/CpmAWS/classes/RdsCollection.py
+++ b/CpmAWS/classes/RdsCollection.py
@@ -22,7 +22,6 @@ class RdsCollection(Collection):
             logging.error(format(e))
             return False
         # filter them
-        logging.notice('Filtering instances...')
         self.instances = self.filter(instances)
         for name in self.instances:
             logging.debug(name)


### PR DESCRIPTION
La modif précédente sur les filtres faisait qu'on ne pouvait plus filtrer sur les instances RDS.